### PR TITLE
increase BLOCK_SIZE to 4M

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -18,7 +18,7 @@ use crate::error::Error;
 use crate::file_cache::FileCache;
 
 const TTL: Duration = Duration::from_secs(1);
-const BLOCK_SIZE: u64 = 4096;
+const BLOCK_SIZE: u64 = 4194304;
 
 #[derive(Debug, Clone)]
 pub struct Inode {


### PR DESCRIPTION
In my case, larger `BLOCK_SIZE` will increase the download speed. (like meaning of large  block size for filesystem). see issue #12

my network(china telecom) bandwidth is 100Mbps. and with BLOCK_SIZE increased to 4M, I can get 107MB/s download speed maximum.

of cause, this size could replace with command arg which provided by user.
thanks for this project.